### PR TITLE
Move endpoint scanner into the policy API

### DIFF
--- a/samples/Authorization.Sample/Controllers/DocsController.cs
+++ b/samples/Authorization.Sample/Controllers/DocsController.cs
@@ -12,51 +12,9 @@ namespace Authorization.Sample.Controllers
         [Route("docs")]
         public IHttpActionResult Get()
         {
-            var explorer = new ApiExplorer(Configuration);
-
-            var endpoints = new List<EndpointSummary>();
-            foreach (var description in explorer.ApiDescriptions)
-            {
-                var action = description.ActionDescriptor;
-
-                var endpoint = new EndpointSummary
-                {
-                    HttpMethod = description.HttpMethod.Method,
-                    Controller = description.ActionDescriptor.ControllerDescriptor.ControllerName,
-                    Action = description.ActionDescriptor.ActionName,
-                    EndpointPath = $"/{description.RelativePath}"
-                };
-
-
-                var pipeline = action.GetFilterPipeline();
-
-                foreach (var filter in pipeline.OfType<PolicyAttribute>())
-                {
-                    endpoint.Policies.Add(filter.PolicyType.Name);
-                }
-
-                endpoints.Add(endpoint);
-            }
+            var endpoints = Configuration.ScanEndpointsForPolicyRequirements();
 
             return Json(endpoints);
-        }
-
-        private class EndpointSummary
-        {
-            public EndpointSummary()
-            {
-                Policies = new HashSet<string>();
-            }
-
-            public string HttpMethod { get; set; }
-
-            public string Controller { get; set; }
-
-            public string Action { get; set; }
-
-            public string EndpointPath { get; set; }
-
-            public ICollection<string> Policies { get; }
         }
     }
 }

--- a/src/Authorization.Core/Authorization.Core.csproj
+++ b/src/Authorization.Core/Authorization.Core.csproj
@@ -54,6 +54,7 @@
     <Compile Include="PolicyContext.cs" />
     <Compile Include="Policy.cs" />
     <Compile Include="PoliciesModule.cs" />
+    <Compile Include="PolicyRequirement.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Authorization.Core/PolicyRequirement.cs
+++ b/src/Authorization.Core/PolicyRequirement.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Authorization
+{
+    public class PolicyRequirement
+    {
+        public PolicyRequirement()
+        {
+            Policies = new HashSet<string>();
+        }
+
+        public string HttpMethod { get; set; }
+
+        public string Controller { get; set; }
+
+        public string Action { get; set; }
+
+        public string EndpointPath { get; set; }
+
+        public ICollection<string> Policies { get; }
+    }
+}

--- a/src/Authorization.WebApi/Authorization.WebApi.csproj
+++ b/src/Authorization.WebApi/Authorization.WebApi.csproj
@@ -56,6 +56,7 @@
   <ItemGroup>
     <Compile Include="AuthenticateAttribute.cs" />
     <Compile Include="ClaimPolicyAttribute.cs" />
+    <Compile Include="HttpConfigurationExtensions.cs" />
     <Compile Include="InRolePolicyAttribute.cs" />
     <Compile Include="PolicyAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Authorization.WebApi/HttpConfigurationExtensions.cs
+++ b/src/Authorization.WebApi/HttpConfigurationExtensions.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Http;
+using System.Web.Http.Description;
+
+namespace Authorization.WebApi
+{
+    public static class HttpConfigurationExtensions
+    {
+        public static ICollection<PolicyRequirement> ScanEndpointsForPolicyRequirements(this HttpConfiguration config)
+        {
+            var explorer = new ApiExplorer(config);
+
+            var endpoints = new List<PolicyRequirement>();
+            foreach (var description in explorer.ApiDescriptions)
+            {
+                var action = description.ActionDescriptor;
+
+                var endpoint = new PolicyRequirement
+                {
+                    HttpMethod = description.HttpMethod.Method,
+                    Controller = description.ActionDescriptor.ControllerDescriptor.ControllerName,
+                    Action = description.ActionDescriptor.ActionName,
+                    EndpointPath = $"/{description.RelativePath}"
+                };
+
+                var pipeline = action.GetFilterPipeline();
+
+                foreach (var filter in pipeline.OfType<PolicyAttribute>())
+                {
+                    endpoint.Policies.Add(filter.PolicyType.Name);
+                }
+
+                endpoints.Add(endpoint);
+            }
+
+            return endpoints;
+        }
+    }
+}


### PR DESCRIPTION
This moves the prototype code for scanning Web API endpoint policies into an extension method for `HttpConfiguration`.